### PR TITLE
llvm-amdgpu: update development branch

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -24,7 +24,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
 
     license("Apache-2.0")
 
-    version("master", branch="amd-stg-open")
+    version("master", branch="amd-staging")
     version("6.2.1", sha256="4840f109d8f267c28597e936c869c358de56b8ad6c3ed4881387cf531846e5a7")
     version("6.2.0", sha256="12ce17dc920ec6dac0c5484159b3eec00276e4a5b301ab1250488db3b2852200")
     version("6.1.2", sha256="300e9d6a137dcd91b18d5809a316fddb615e0e7f982dc7ef1bb56876dff6e097")


### PR DESCRIPTION
This updates `llvm-amdgpu@master` to use `amd-staging`, since that's now the default branch for the GitHub repo: https://github.com/ROCm/llvm-project/branches.

Someone from AMD should confirm this is the right thing to do.

Closes https://github.com/spack/spack/issues/46986.